### PR TITLE
Added size limits to grid

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use crate::utils::maths::{SirParams, count_states};
 use crate::utils::simulation::step_grid;
 
 fn main() {
+
     // 1. Define simulation parameters (including infection ratios)
     let params = SirParams {
         beta: 0.3,         // Infection rate
@@ -19,9 +20,13 @@ fn main() {
     };
 
     // 2. Initialize grid using SirParams
-    let mut grid = Grid::init(100, 100, &params);
+    let mut grid = Grid::init(8, 15, &params);
+
+    let (cell_size, heap_size, struct_size) = grid.get_grid_size();
+    println!("cell_size {}, heap_size {}, struct_size {}",cell_size, heap_size, struct_size);
 
     // 3. Run simulation loop
+    
     let mut day = 0;
     loop {
         let stats = count_states(&grid);

--- a/src/utils/grid.rs
+++ b/src/utils/grid.rs
@@ -25,12 +25,22 @@ impl Grid {
     /// Creates a new grid of given dimensions.
     /// Uses `i_ratio` from `SirParams` to determine the fraction of cells initialized as infected.
     pub fn init(grid_x: usize, grid_y: usize, params: &SirParams) -> Self {
+
+        let max_cells = 1_000_000_000; // 10 million max cells
         let size = grid_x * grid_y;
+
+        if size > max_cells {
+            panic!(
+                "Grid too large: {}x{} = {} cells. Limit is {}.\n\
+                 Please reduce the grid size (e.g., grid_x * grid_y <= {}).",
+                grid_x, grid_y, size, max_cells, max_cells
+            );
+        }
 
         let cells = (0..size)
             .map(|_| {
                 let mut rng = rand::thread_rng();
-                let roll = rng.r#gen::<f64>(); // 🔥 This must use `gen` from `Rng`
+                let roll = rng.r#gen::<f64>(); 
                 let state = if roll < params.i_ratio {
                     HealthState::Infected
                 } else {
@@ -46,7 +56,6 @@ impl Grid {
             cells,
         }
     }
-
     pub fn get_grid_size(&self) -> (usize, usize, usize) {
         let cell_size = size_of::<Cell>();
         let heap_size = self.cells.len() * cell_size;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The grid now displays its cell size, heap size, and structure size in the console after initialization.
- **Bug Fixes**
  - Added a check to prevent grid sizes larger than 1,000,000,000 cells, with a clear error message if exceeded.
- **Other Changes**
  - Default grid dimensions changed to 8x15.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->